### PR TITLE
Remove verbose arg from auto

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ workflows:
           # tokens. We include a context that has our publish credentials
           # explicitly in this step. https://circleci.com/docs/2.0/contexts/
           context: npm-deploy
-          args: --verbose
           filters:
             branches:
               only: master


### PR DESCRIPTION
I had `verbose` mode enabled for auto to debug some deployment issues. Those are fixed now so I'm removing this flag.